### PR TITLE
fix: Define inline provider directory

### DIFF
--- a/providers.d/inline/post_training/kfp-torchtune.yaml
+++ b/providers.d/inline/post_training/kfp-torchtune.yaml
@@ -1,0 +1,5 @@
+adapter_type: kfp-torchtune
+pip_packages: ["torch", "torchtune==0.5.0", "torchao==0.8.0", "numpy", "kfp", "kubernetes"]
+config_class: llama_stack_provider_kfp_trainer.config.TorchtuneKFPTrainerConfig
+module: llama_stack_provider_kfp_trainer
+api_dependencies: ["datasetio", "datasets"]

--- a/providers.d/remote/post_training/kfp-torchtune.yaml
+++ b/providers.d/remote/post_training/kfp-torchtune.yaml
@@ -4,4 +4,3 @@ adapter:
   config_class: llama_stack_provider_kfp_trainer.config.TorchtuneKFPTrainerConfig
   module: llama_stack_provider_kfp_trainer
 api_dependencies: ["datasetio", "datasets"]
-optional_api_dependencies: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [project]
 dependencies = [
-    # TODO: why are some dependencies like fastapi in [dev]?
-    "llama-stack[dev]>=0.2.5",
+    "llama-stack>=0.2.5",
     "kfp",
     # from upstream torchtune provider
     "torchtune==0.5.0",

--- a/scripts/prepare-venv.sh
+++ b/scripts/prepare-venv.sh
@@ -10,6 +10,7 @@ pip install --upgrade pip
 # the reference provider is loaded when no telemetry section is configured
 pip install opentelemetry-sdk opentelemetry-exporter-otlp-proto-http
 
-# This dependency doesn't seem to be tracked at all
-pip install aiosqlite
+# Install some dependencies not pulled by llama-stack for some reason
+pip install aiosqlite fastapi uvicorn
+
 pip install .


### PR DESCRIPTION
This is to reflect llama-stack expectations about the directories -
inline providers to list providers with "local" mode of operations.
